### PR TITLE
Nuevo tipo de Dato (RefMap) y Actualización de Documentación

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 *.out
 *.o
 *.h.gch
+
+# Archivos generados por Doxygen
+/html
+/latex

--- a/RefMap.c
+++ b/RefMap.c
@@ -1,0 +1,650 @@
+// Universidad de Carabobo. FaCYT
+// Sistemas Operativos
+// Gabriel Peraza. CI: 26.929.687
+
+// Liberías de C y POSIX/Unix:
+#include "RefMap.h"
+// Liberías de C y POSIX/Unix:
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <errno.h>  // errno y perror()
+#include <math.h>   // REQUIRES -lm
+
+#define LT -1
+#define EQ 0
+#define GT 1
+
+// Inline dynamic memory management:
+#define STOP_IF_UNSAFE( ptr , err_msg )             \
+    do { if( ptr == NULL ){                         \
+            fprintf( stderr , "%s\n\n" , err_msg ); \
+            exit( 1 ); }                            \
+    } while(0);
+
+//Inline stack operations:
+#define PUSH(stack,counter,element) \
+        stack[counter]   = element; \
+        counter         += 1;       \
+        
+#define POP(stack,counter,element)  \
+    counter -= 1;                   \
+    element  = stack[counter];      \
+
+#define EMPTY (used == 0)
+
+
+//      ---------------------------------------
+//      [*] Declaración de funciones estáticas: (visibles sólo dentro de este archivo)
+//      ---------------------------------------
+
+static void    init         ( NodeRB* node , void* key , void* value , COLOR color , int N );
+static NodeRB* rotateLeft   ( NodeRB* h );
+static NodeRB* rotateRight  ( NodeRB* h );
+static void    flipColors   ( NodeRB* h );
+static NodeRB* balance      ( NodeRB* h );
+static NodeRB* moveRedRight ( NodeRB* h );
+static NodeRB* moveRedLeft  ( NodeRB* h );
+static void*   deleteMin    ( NodeRB** h ); // [$] Mutable traversal. Returns the retrieved key.
+static void*   delete       ( NodeRB** root , void* key , int (*compare)(void*,void*) );    // [$] Mutable traversal. Returns the extracted key.
+static NodeRB* minimum      ( NodeRB* h );
+static int     contains     ( NodeRB* node , void* key , int (*cmp)(void*,void*) );
+static NodeRB* get          ( NodeRB* node , void* key , int (*cmp)(void*,void*) );
+static int     isRed        ( NodeRB* node );
+static COLOR _flipcolor ( COLOR c );
+
+// Refmap private functions:
+static void refmap_unsafe_delete   ( RefMap* t , void* key );
+static void refmap_unsafe_deleteMin( RefMap* t );
+
+static void print_opaque( void *unknow );
+static void debug( NodeRB* x , int indent , int incr ,
+                   char black[] , char red[] , char normal[] ,
+                   void (*key)(void*) , void (*val)(void*) );
+
+//      ------------------------------
+//      [_] Private functions (NodeRB)
+//      ------------------------------
+
+static void init( NodeRB* node , void* key , void* value , COLOR color , int N ){
+    // Llave y contenido:
+    node->key   = key;
+    node->value = value;
+
+    // Datos del árbol
+    node->color = color;
+    node->N     = N;
+
+    // Sin hijos:
+    node->left  = NULL;
+    node->right = NULL;
+}
+
+static int isRed( NodeRB* node ){
+    if( node == NULL ) return 0;
+    else               return node->color == RED;
+}
+
+static int nodeSize( NodeRB* node ){
+    if( node == NULL ) return 0;
+    else               return node->N;
+}
+
+// Retorna la nueva raíz del sub-árbol h luego de aplicar la rotación.
+static NodeRB* rotateLeft( NodeRB* h ){
+    // Rotate left (Robert Sedgewick, Kevin Wayne. Algorithms 4th ed.) 
+    /*  ANTES:
+                E   <-- h
+              /   \
+            <%     S  <-- x
+                 /  \
+                <@  #>
+      
+        DESPUÉS:
+                   S  <-- x
+                 /  \
+          h --> E   #>
+              /  \
+            <%   <@
+    */
+    
+    NodeRB* x = h->right;
+    h->right  = x->left;
+    x->left   = h;
+
+    x->color  = h->color;
+    h->color  = RED;
+
+    x->N      = h->N;
+    h->N      = 1 + nodeSize(h->left) + nodeSize(h->right);
+    return x;
+}
+
+// Retorna la nueva raíz del sub-árbol h luego de aplicar la rotación.
+static NodeRB* rotateRight( NodeRB* h ){
+    // Rotate Right:
+    NodeRB* x = h->left;
+    h->left   = x->right;
+    x->right  = h;
+
+    x->color  = h->color;
+    h->color  = RED;
+
+    x->N      = h->N;
+    h->N      = 1 + nodeSize(h->left) + nodeSize(h->right);
+    return x;
+}
+
+// Retorna el color opuesto.
+static COLOR _flipcolor( COLOR c ){
+    return (COLOR) !( (int) c );
+}
+
+// Pre{ node != NULL }
+static void flipColors( NodeRB* h ){
+    h->color        = _flipcolor(h->color);
+    h->left->color  = _flipcolor(h->left->color);
+    h->right->color = _flipcolor(h->right->color);
+}
+
+static NodeRB* moveRedLeft( NodeRB* h ){
+    flipColors(h);
+    if( isRed(h->right->left) ){
+        h->right = rotateRight(h->right);
+        h        = rotateLeft(h);
+        flipColors(h);
+    }
+    return h;
+}
+
+// Invierte los colores y rota cuando el nieto no es rojo.
+static NodeRB* moveRedRight( NodeRB* h ){
+    flipColors(h);
+    if( isRed(h->left->left) ){
+        h = rotateRight(h);
+        flipColors(h);
+    }
+    return h;
+}
+
+// Contiene la clave?
+static int contains( NodeRB* node , void* key , int (*cmp)(void*,void*) ){    // (11)
+    return get(node,key,cmp) != NULL;
+}
+
+static NodeRB* get( NodeRB* node , void* key , int (*cmp)(void*,void*) ){
+    NodeRB* search = node;
+    while( search != NULL ){
+        switch( (*cmp)(key,search->key) ){
+            case LT: search = search->left;  continue;
+            case EQ: return search;          continue;
+            case GT: search = search->right; continue;
+        }
+    }
+    return search;
+}
+
+static NodeRB* minimum( NodeRB* h ){
+    NodeRB* min = h;
+    while( min->left != NULL )
+        min = min->left;
+    return min;
+}
+
+// Balancea la carga del subárbol:
+static NodeRB* balance( NodeRB* h ){
+    if( isRed(h->right) && !isRed(h->left)       ) h = rotateLeft(h);
+    if( isRed(h->left)  &&  isRed(h->left->left) ) h = rotateRight(h);
+    if( isRed(h->left)  &&  isRed(h->right)      ) flipColors(h);
+
+    h->N = nodeSize(h->left) + nodeSize(h->right) + 1;
+    return h;
+}
+
+
+//      ----------------------------------------------
+//      [#] Definición de funciones visibles (RefMap):
+//      ----------------------------------------------
+// Utilidades del árbol rojo y negro.
+
+void refmap_init( RefMap* t                            ,
+                  int   (*cmp)           (void*,void*) ,
+                  void* (*copyProtocol)        (void*) ,
+                  void  (*deallocationProtocol)(void*) ){
+    STOP_IF_UNSAFE( copyProtocol , "refmap_init: Attempt to passing an invalid copyProtocol." );
+
+    t->root    = NULL;
+    t->cmp     = cmp;
+    t->copykey = copyProtocol;
+    if( deallocationProtocol == NULL ) t->freekey = free;
+    else                               t->freekey = deallocationProtocol;
+    // Atomicity:
+    pthread_mutex_init( &(t->lock) , NULL ); // Do not pass any particular attribute.
+}
+
+int refmap_unsafe_empty( RefMap* t ){ return t->root == NULL; }
+int refmap_unsafe_size ( RefMap* t ){ return nodeSize( t->root ); }
+
+static int maxDepth( NodeRB* root ){
+    if( root == NULL ) return 0;
+
+    double depthD = ceil( log2(root->N) );
+    int    depthI = (int) depthD;
+    return depthI * 2;
+}
+
+// [$] Mutable traversal
+// Worst-case cost 2*log2(N):
+void refmap_unsafe_put( RefMap* t , void* key , void* value ){
+    static int extra = 2;
+
+    // :::::::::::::::::::::::
+    // Non-Recursive Interface
+    // :::::::::::::::::::::::
+    // -- Nothing in particular for this case --
+
+    // [^] Build Stack:
+    NodeRB*** stack;
+    int used = 0;
+    int size = maxDepth( t->root ) + extra;
+
+    stack = malloc( size * sizeof(NodeRB**) );
+    STOP_IF_UNSAFE( stack , "refmap_unsafe_put: Unable to build stack" );
+
+    // [F] Function Pointers:
+    int   (*compare) (void*,void*) = t->cmp;
+    void* (*allocate)(void*)       = t->copykey;
+
+    // [S] Search:
+    NodeRB** head;
+    NodeRB*  node;
+    int      DONE = 0;
+
+    // Prelude:
+    PUSH( stack , used , &t->root );
+    // Mutable traversal:
+    while( !DONE ){
+        if( EMPTY ){ perror("refmap_unsafe_put: Stack smashed in bottom"); exit(1); }
+        POP( stack , used , head );
+        
+        node = *head;
+        if( node == NULL ){
+            node        = malloc( sizeof(NodeRB) );
+            void* clone = (*allocate)( key );
+            STOP_IF_UNSAFE( clone , "refmap_unsafe_put: "
+                                    " Unable to allocate memory for key." );
+            STOP_IF_UNSAFE( node  , "refmap_unsafe_put: "
+                                    " Unable to allocate memory for Node." );
+            init( node , clone , value , RED , 1 );
+            *head = node;
+
+            DONE = 1;
+            continue; // EXIT Recursive case.
+        }
+
+        // Recursive Step:
+        switch( (*compare)(key , node->key) ){
+            case LT:
+                PUSH( stack , used , head );            // Needs to be balanced.
+                PUSH( stack , used , &node->left );     // Go to down-left.
+                continue;
+            case EQ:
+                node->value = value;
+                PUSH( stack , used , head );            // Needs to be balanced.
+                DONE = 1;
+                continue; // EXIT Recursive case.
+            case GT:
+                PUSH( stack , used , head );            // Needs to be balanced.
+                PUSH( stack , used , &node->right );    // Go to down-right.
+                continue;
+        }
+    }
+
+    while( !EMPTY ){
+        POP( stack , used , head );
+        // Fix-up any right-leaning links:
+        // Line 1. Larger case; Line 2. Smaller case; Line 3. Between case;
+        if( isRed((*head)->right) && !isRed((*head)->left)       ) (*head) = rotateLeft(*head);
+        if( isRed((*head)->left ) &&  isRed((*head)->left->left) ) (*head) = rotateRight(*head);
+        if( isRed((*head)->left ) &&  isRed((*head)->right)      ) flipColors(*head);
+
+        // Size update:
+        node = *head;
+        node->N = nodeSize(node->left) + nodeSize(node->right) + 1;
+    }
+
+    // [$!] TOTALLY REQUIRED:
+    free( stack );
+
+    // :::::::::::::
+    // Exit Protocol
+    // :::::::::::::
+    t->root->color = BLACK;
+}
+
+    
+void refmap_put( RefMap* t , void* key , void* value ){
+    // |> BEGIN CRITICAL REGION
+    pthread_mutex_lock( &t->lock );
+    refmap_unsafe_put( t , key , value );
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &t->lock );
+}
+
+void* refmap_unsafe_get( RefMap* t , void* key ){
+    if( t->root == NULL ) return NULL;
+    else                  return get( t->root , key , t->cmp )->value;
+}
+
+void* refmap_extract( RefMap* t , void* key ){
+    // |> BEGIN CRITICAL REGION
+    pthread_mutex_lock( &t->lock );
+    void* value = refmap_unsafe_get( t , key );
+    refmap_unsafe_delete( t , key );
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &t->lock );
+
+    return value;
+}
+
+// [$] Mutable traversal
+// Returns the retrieved key.
+static void* delete( NodeRB** root , void* key , int (*compare)(void*,void*) ){
+    static int extra = 1;   // counts the head and the new node.
+
+    // [^] Build Stack:
+    NodeRB*** stack;
+    int used = 0;
+    int size = maxDepth( *root ) + extra;
+
+    stack = malloc( size * sizeof(NodeRB**) );
+    STOP_IF_UNSAFE( stack , "delete (NodeRB): Unable to build stack" );
+
+    // [S] Search:
+    NodeRB** head;
+    NodeRB*  node;
+    int      DONE = 0;
+    void*   extracted_key = NULL;
+
+    PUSH( stack , used , root );
+    while( !DONE ){
+        if( EMPTY ){ perror("delete (NodeRB): Stack smashed in bottom."); exit(1); }
+        POP( stack , used , head );
+
+        node = *head;
+        if( (*compare)(key , node->key) == LT ){
+            if( !isRed(node->left) && !isRed(node->left->left) ){
+                node  = moveRedLeft( node );
+                *head = node;
+            }
+
+            PUSH( stack , used , head );        // Requires to be balanced.
+            PUSH( stack , used , &node->left );  // Go to down-left
+        } else {
+            if( isRed(node->left) ){ // Adjust.
+                node  = rotateRight(node);
+                *head = node;
+            }
+
+            if( (*compare)(key , node->key) == EQ && node->right == NULL ){
+                extracted_key = node->key;
+                node->key   = NULL;
+                node->left  = NULL;
+                node->right = NULL;
+                // DEALLOCATE:
+                free( *head );
+                *head = NULL;
+
+                DONE = 1;
+                continue; // EXIT Recursive case.
+            }
+
+            if( !isRed(node->right) && !isRed(node->right->left) ){
+                node  = moveRedRight(node);
+                *head = node;
+            }
+
+            if( (*compare)(key , node->key) == EQ ){
+                // DEALLOCATE KEY.
+                extracted_key = node->key;
+
+                // DELEGATE NODE DEALLICATION:
+                node->value = minimum( node->right )->value;
+                node->key   = deleteMin( &node->right );
+
+                PUSH( stack , used , head );            // NOTE: Requires to be balanced
+                DONE = 1;
+                continue; // EXIT Recursive case.
+            } else {
+                PUSH( stack , used , head );            // Requires to be balanced
+                PUSH( stack , used , &node->right );    // Go to down-right.
+                continue;
+            }
+        }
+    }
+
+    while( !EMPTY ){
+        POP( stack , used , head );
+        *head = balance(*head);
+    }
+
+    // [$!] TOTALLY REQUIRED:
+    free( stack );
+
+    return extracted_key;
+}
+
+static void refmap_unsafe_delete( RefMap* t , void* key ){
+    if( !refmap_unsafe_contains(t,key) ) return;
+
+    NodeRB* root = t->root;
+    if( !isRed(root->left) && !isRed(root->right) )
+        root->color = RED;
+
+    void* old_key = delete( &t->root , key , t->cmp );
+    (*t->freekey)( old_key );
+
+    if( !refmap_unsafe_empty(t) )
+        t->root->color = BLACK;
+}
+
+void refmap_delete( RefMap* t , void* key ){
+    // |> BEGIN CRITICAL REGION
+    pthread_mutex_lock( &t->lock );
+    refmap_unsafe_delete( t , key );
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &t->lock );
+}
+
+static void refmap_unsafe_deleteMin( RefMap* t ){
+    // Initial Interface:
+    if( refmap_unsafe_empty(t) ) return;
+
+    NodeRB* root = t->root;
+    if( !isRed(root->left) && !isRed(root->right) )
+        t->root->color = RED;
+
+    void* old_key = deleteMin(&t->root);
+    (*t->freekey)( old_key );
+
+    if( !refmap_unsafe_empty(t) )
+        t->root->color = BLACK;
+}
+
+// [$] Mutable traversal
+static void* deleteMin( NodeRB** root ){
+    static int extra = 1;   // counts the head and the new node.
+
+    // [^] Build Stack:
+    NodeRB*** stack;
+    int used = 0;
+    int size = maxDepth( *root ) + extra;
+
+    stack = malloc( size * sizeof(NodeRB**) );
+    STOP_IF_UNSAFE( stack , "deleteMin (NodeRB): Unable to build stack" );
+
+    // [S] Search:
+    NodeRB** head;
+    NodeRB*  node;
+    int      DONE = 0;
+    void*   extracted_key = NULL;
+
+    PUSH( stack , used , root );
+    while( !DONE ){
+        if( EMPTY ){ perror("deleteMin (NodeRB): Stack smashed in bottom."); exit(1); }
+        POP( stack , used , head );
+        node = *head;
+
+        if( node->left == NULL ){
+            // DEALOCATE.
+            extracted_key = node->key;
+            node->key   = NULL;
+            node->left  = NULL;
+            node->right = NULL;
+            node->value = NULL;
+
+            free( *head );
+            *head = NULL;
+
+            DONE = 1;
+            continue;   // EXIT Recursive case.
+        }
+        
+        if( !isRed(node->left) && !isRed(node->left->left) ){
+            node  = moveRedLeft(node);
+            *head = node;
+        }
+
+        PUSH( stack , used , head );
+        PUSH( stack , used , &node->left );
+    }
+
+    while( !EMPTY ){
+        POP( stack , used , head );
+        *head = balance(*head);
+    }
+
+    // [$!] TOTALLY REQUIRED:
+    free( stack );
+
+    return extracted_key;
+}
+
+void refmap_deleteMin( RefMap* t ){
+    // |> BEGIN CRITICAL REGION
+    pthread_mutex_lock( &t->lock );
+    refmap_unsafe_deleteMin( t );
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &t->lock );
+}
+
+int refmap_unsafe_contains( RefMap* t , void* key ){
+    return contains(t->root, key ,t->cmp);
+}
+
+// Prints always in stderr. key() and val() must print in stderr too.
+static void debug( NodeRB* x , int indent , int incr ,
+                   char black[] , char red[] , char normal[] ,
+                   void (*key)(void*) , void (*val)(void*) ){
+
+    if( x == NULL ) return;
+    fprintf( stderr , "%*skey:   " , indent , "|> " );
+    (*key)( x->key );
+    putc( '\n' , stderr );
+
+    fprintf( stderr , "%*svalue: " , indent , "  +" );
+    (*val)( x->value );
+    putc( '\n' , stderr );
+    fprintf( stderr , "%*ssize:  %d\n" , indent , "   " , x->N );
+
+    if( x->color == RED ) fprintf( stderr , "%*ccolor: %s%s" , indent , ' ' , red   , "RED   (<<L 3-nodes)" );
+    else                  fprintf( stderr , "%*ccolor: %s%s" , indent , ' ' , black , "BLACK (=RL 2-nodes)" );
+    fprintf( stderr , "%s\n" , normal );
+    fprintf( stderr , "%*cleft:\n"    , indent , ' ' );
+    debug( x->left  , indent + incr , incr , black , red , normal , key , val );
+    debug( x->right , indent + incr , incr , black , red , normal , key , val );
+}
+
+static void print_opaque( void *unknow ){
+    fprintf( stderr , "(void*) %p" , unknow );
+}
+
+void refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) , void (*print_value)(void*) ){
+    static char black[]  = "\x1b[38;5;32m";
+    static char red[]    = "\x1b[38;5;9m";
+    static char normal[] = "\x1b[0m";
+
+    if( print_key   == NULL ) print_key   = &print_opaque;
+    if( print_value == NULL ) print_value = &print_opaque;
+
+    char *ublack , *ured , *unormal;
+    if( use_ascii_color ){
+        ublack  = black;
+        ured    = red;
+        unormal = normal;
+    } else
+        ublack = ured = unormal;
+    fprintf( stderr , "%s" , unormal );
+    debug( t->root , 4 , 4 ,
+           ublack , ured , unormal ,
+           print_key , print_value );
+    fprintf( stderr , "%s" , unormal );
+}
+
+void refmap_clear( RefMap* t ){
+    RefMap* self = t;
+    // <| BEGIN CRITICAL REGION
+    pthread_mutex_lock( &self->lock );
+
+    void* k , *outk;
+    while( !refmap_unsafe_empty(t) ){
+        k    = t->root->key;
+        refmap_unsafe_delete( t , k );
+    }
+
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &self->lock );
+}
+
+void refmap_destroy( RefMap* t ){
+    RefMap* self = t;
+    // <| BEGIN CRITICAL REGION
+    pthread_mutex_lock( &self->lock );
+
+    void* k , *outk;
+    // BUG: when deletes the 6th elements, it delete twice, idk why, I must see what happens!
+    while( !refmap_unsafe_empty(t) ){
+        //refmap_debug(t);
+        k    = t->root->key;
+        refmap_unsafe_delete( t , k );
+    }
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &self->lock );
+
+    pthread_mutex_destroy( &self->lock );
+}
+
+void* refmap_unsafe_min( RefMap* t ){
+    if( t->root == NULL ) return NULL;
+    else                  return minimum(t->root)->key;
+}
+
+void* refmap_extract_min( RefMap* t ){
+    // |> BEGIN CRITICAL REGION
+    pthread_mutex_lock( &t->lock );
+    void* value = refmap_unsafe_min(t);
+    refmap_unsafe_deleteMin( t );
+    // <| END CRITICAL REGION
+    pthread_mutex_unlock( &t->lock );
+    return value;
+}
+
+#undef LT
+#undef EQ
+#undef GT
+#undef STOP_IF_UNSAFE
+#undef PUSH
+#undef POP
+#undef EMPTY

--- a/RefMap.h
+++ b/RefMap.h
@@ -1,0 +1,195 @@
+/**
+ * @file RefMap.h
+ * @brief Define el tipo de datos RefMap, que puede ser usado para
+ *        preservar el orden de los elementos al proporcionar llaves
+ *        de búsqueda.
+ * @author Gabriel Peraza
+ * @version 1.0.0.0
+ * @date 2021-02-08
+ */
+
+// Estándar usado: __PAQUETE__SUBPAQUETE__ ... __NOMBRE_MODULO_
+#ifndef __REFMAP_H__
+#define __REFMAP_H__
+
+// Liberías de C y POSIX/Unix:
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <errno.h>  // errno y perror()
+#include <math.h>   // REQUIRES -lm
+
+// ----------------------------------------------------------------------------------
+// NOTE:    Se ha utilizado la estructura de datos Red-Black Trees del curso
+//          Algorithms de Robert Sedgewick y Kevin Wayne. El material está disponible
+//          en línea en su página https://algs4.cs.princeton.edu/
+// ----------------------------------------------------------------------------------
+
+/// @typedef COLOR
+/// @brief Tipo de enlace.
+/// @details BLACK implica que se tiene un nodo con dos enlaces (L, R) en cambio, RED implica
+///          que el nodo tiene tres enlaces (L, C, R).
+typedef enum { BLACK = 0 , RED = 1 } COLOR;
+
+/// @brief Nodo Usado dentro del de RefMap.
+/// @details No almacena espacio para los valores(value) sólo sus referencias. Sin embargo
+///          Puede reservar espacio para las llaves(key) si se sumistra un protocolo de copia
+///          Adecuado.
+typedef struct _nodeRB{
+    void*  key;             ///< Clave de comparación.
+    void*  value;           ///< Valor arbitrario.
+    struct _nodeRB* left;   ///< sub-árbol izquierdo.
+    struct _nodeRB* right;  ///< sub-árbol derecho.
+    COLOR  color;           ///< color del enlace desde el padre hasta este nodo. [RED ó BLACK].
+                            ///< En el material, se utiliza un booleano para representar el color.
+                            ///< donde true === RED y black === false.
+    int             N;      ///< número de nodos en este sub-árbol.
+    // NOTE: Se ha cambiado el orden de los elementos para reducir el tamaño de la estructura
+    //       causado por el padding. Antes, se usaban 8 bytes extras para el alignment &
+    //       padding y utilizaba 48 Bytes. con este ajuste, se utilizan 40 bytes... Una
+    //       mejora del 16.67% en cuanto la administración de memoria!
+} NodeRB;
+
+/// @brief Diccionario o Mapa basado en la estructura de datos Red-Black Trees.
+typedef struct RefMap{
+    // Atomicidad:
+    pthread_mutex_t lock;               ///< Asegura la exclusión mutua.
+
+    NodeRB* root;                       ///< Raíz del árbol
+    // Metodos especiales:
+    void* (*copykey)( void* key );      ///< Protocolo para copiar las claves. Asegura que sean inmutables.
+    void  (*freekey)( void* key );      ///< Protocolo para liberar el espacio reservado para las claves.
+    int (*cmp) ( void* k1 , void* k2 ); ///< Protocolo para comparar las claves.
+} RefMap;
+
+//      -----------------------------
+//      [*] Declaración de funciones:
+//      -----------------------------
+
+/// @brief Inicializa un diccionario o mapa.
+/// @param t Mapa destino.
+/// @param cmp Protocolo de comparación de las claves.
+/// @param copyProtocol Protocolo para copiar las claves.
+/// @param deallocationProtocol Protocolo para liberar las claves.
+void   refmap_init       ( RefMap* t,
+                           int   (*cmp) (void*,void*),
+                           void* (*copyProtocol)(void*),
+                           void  (*deallocationProtocol)(void*) );  // ()
+void   refmap_put        ( RefMap* t , void* key , void* value );   // ()
+void*  refmap_extract    ( RefMap* t , void* key );         // ()
+void*  refmap_extract_min( RefMap* t );                     // ()
+void   refmap_delete     ( RefMap* t , void* key );         // ()
+void   refmap_deleteMin  ( RefMap* t );                     // ()
+void   refmap_clear      ( RefMap* t );                     // ()
+void   refmap_destroy    ( RefMap* t );                     // ()
+
+void*  refmap_unsafe_get   ( RefMap* t , void* key );       // ()
+int    refmap_unsafe_empty ( RefMap* t );                   // ()
+int    refmap_unsafe_size  ( RefMap* t );                   // ()
+int    refmap_unsafe_contains ( RefMap* t , void* key );    // ()
+void*  refmap_unsafe_min( RefMap* t );                      // ()
+/// @brief Muestra el mapa en stderr.
+/// @param t Mapa objetivo.
+/// @param use_ascii_color Lógico. si es 0, no muestra colores. si es 1 muestra colores. (Formato Unix)
+/// @param print_key Protocolo para mostrar la clave en stderr.
+/// @param print_value Protocolo para mostrar el valor en stderr.
+/// @warning No es Thread-safe.
+void   refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) , void (*print_value)(void*) );
+
+/// @fn void refmap_init( RefMap* t, int (*cmp) (void*,void*), void* (*copyProtocol)(void*), void (*deallocationProtocol)(void*) )
+/// @brief Inicializa un diccionario o mapa.
+/// @param t Mapa destino.
+/// @param cmp Protocolo de comparación de las claves.
+/// @param copyProtocol Protocolo para copiar las claves.
+/// @param deallocationProtocol Protocolo para liberar las claves.
+
+/// @fn void refmap_put( RefMap* t , void* key , void* value )
+/// @brief Inserta o Reemplaza la referencia de un valor dentro del mapa.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @param value Referencia del valor a insertar/reemplazar
+
+/// TODO: modificar errno cuando no se encuentra ningún elemento.
+/// @fn void* refmap_extract( RefMap* t , void* key )
+/// @brief Extrae la referencia del valor asociado para key.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @param value Referencia del valor a insertar/reemplazar
+/// @returns Referencia del valor asociado con key. Si no se encuentra key, retorna NULL.
+/// @details Obtiene y remueve la referencia del mapa, mediante la exclusión mutua.
+
+
+/// @fn void* refmap_extract_min( RefMap* t )
+/// @brief Extrae el valor asociado para la clave más pequeña del mapa.
+/// @param t Mapa objetivo.
+/// @returns Referencia del valor asociado con key. Si no se encuentra key, retorna NULL.
+/// @see refmap_extract
+
+
+/// @fn void refmap_delete( RefMap* t , void* key )
+/// @brief Remueve el valor asociado para la clave proporcionada.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @details Remueve la referencia del mapa, mediante la exclusión mutua.
+
+/// @fn void refmap_deleteMin( RefMap* t )
+/// @brief Remueve el valor asociado para la clave más pequeña del mapa.
+/// @param t Mapa objetivo.
+/// @see refmap_delete
+
+/// @fn void refmap_clear( RefMap* t )
+/// @brief Remueve todas las referencias del mapa.
+/// @param t Mapa objetivo.
+/// @details El mapa queda vacío una vez aplicada la operación.
+
+/// @fn void refmap_destroy( RefMap* t )
+/// @brief Remueve todas las referencias del mapa y destruye el mapa.
+/// @param t Mapa objetivo.
+/// @details El mapa queda vacío una vez aplicada la operación. Destruye los objetos usados
+///          para asegurar la exclusión mutua.
+/// @see refmap_clear
+
+/// @fn void* refmap_unsafe_get( RefMap* t , void* key )
+/// @brief Consulta el valor asociado a la clave proporcionada dentro de un mapa.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @warning No es Thread-safe.
+/// @return Referencia del objeto asociado con key. NULL si no se encuentra dentro del mapa.
+
+/// @fn int refmap_unsafe_empty( RefMap* t );
+/// @brief Verifica si el mapa está vacío.
+/// @param t Mapa objetivo.
+/// @warning No es Thread-safe.
+/// @return Lógico. Verdad si está vacío.
+
+/// @fn int refmap_unsafe_size( RefMap* t );
+/// @brief Consulta el número de elementos dentro del mapa.
+/// @param t Mapa objetivo.
+/// @warning No es Thread-safe.
+/// @return Número de elementos dentro del mapa. 0 si está vacío.
+
+/// @fn int refmap_unsafe_contains( RefMap* t , void* key )
+/// @brief Consulta si la clave está dentro del mapa.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @warning No es Thread-safe.
+/// @return Lógico. Verdad si key está dentro de t.
+
+/// @fn void* refmap_unsafe_min( RefMap* t )
+/// @brief Consulta el valor asociado con la clave más pequeña del mapa.
+/// @param t Mapa objetivo.
+/// @warning No es Thread-safe.
+/// @return Referencia del valor asociado con la clave más pequeña. NULL si está vacío.
+
+
+/// @fn void refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) , void (*print_value)(void*) );
+/// @brief Muestra el mapa en stderr.
+/// @param t Mapa objetivo.
+/// @param use_ascii_color Lógico. si es 0, no muestra colores. si es 1 muestra colores. (Formato Unix)
+/// @param print_key Protocolo para mostrar la clave en stderr.
+/// @param print_value Protocolo para mostrar el valor en stderr.
+/// @warning No es Thread-safe.
+
+#endif

--- a/RefQueue.c
+++ b/RefQueue.c
@@ -9,10 +9,15 @@
 // DEPENDIENTE DE UNIX:
 #include <pthread.h>
 
+#define STOP_IF_UNSAFE( ptr , err_msg ) \
+    do { if( ptr == NULL ){             \
+            perror( err_msg );          \
+            exit( 1 ); }                \
+    } while(0);
+
 // Declaracion de funciones estáticas (visibles sólo para el archivo actual)
 static void  refqueue_unsafe_put  ( RefQueue* qs , void* elem );
 static void* refqueue_unsafe_get  ( RefQueue* qs );
-static void* refqueue_unsafe_clean( RefQueue* qs );
 static char* refqueue_unsafe_str  ( RefQueue* xs );
 static char* opaque_object_str    ( void* ignored );
 
@@ -23,6 +28,7 @@ static void free_node( _LNode* node , void (*free_obj)(void*) );
 
 static _LNode* new_node( void* e ){
     _LNode* node = (_LNode*) malloc(sizeof(_LNode));
+    STOP_IF_UNSAFE( node , "[new_node] allocation_error" );
     node->item = e;
     node->next = NULL;
     return node;
@@ -38,6 +44,10 @@ static void free_node( _LNode* node ,
                        void (*free_obj)(void*) ){
     (*free_obj)(node->item);
     free(node);
+}
+
+void refqueue_singleton( RefQueue* qs ){
+    refqueue_init( qs , NULL , NULL );
 }
 
 // NOTE: xs->str() debe ser una función que tome un objeto de la cola
@@ -144,6 +154,7 @@ static char* opaque_object_str( void* ignored ){
     const char dummyObj[] = "(*)";
     const int  size       = sizeof(dummyObj);
     char* str = malloc( size * sizeof(char) + 1 );
+    STOP_IF_UNSAFE( str , "[opaque_object_str] allocation error" );
     strcpy( str , dummyObj );
     return str;
 }
@@ -157,8 +168,11 @@ static char* refqueue_unsafe_str( RefQueue* xs ){
     _LNode* node   = xs->head;
     char** elems   = malloc(xs->n * sizeof(char*));
     int*   lengths = malloc(xs->n * sizeof(int)  );
-    int    size    = 0; // Using size
-    char* (*toStr)(void*) = xs->str? xs->str : opaque_object_str;
+    int    size    = 0;
+    char* (*toStr)(void*) = xs->str? xs->str : opaque_object_str; // Which will be used to print?
+
+    STOP_IF_UNSAFE( elems   , "[refqueue_unsafe_str] allocation error (str set)" );
+    STOP_IF_UNSAFE( lengths , "[refqueue_unsafe_str] allocation error (lengths set)" );
 
     // Prints something cool:
     for( int i = 0 ; i < xs->n ; i += 1 ){
@@ -174,6 +188,8 @@ static char* refqueue_unsafe_str( RefQueue* xs ){
         size   += slen + ((xs->n - 1) * clen) + elen;
     char* str  = malloc( size + 1 );
     char* curr = str;
+
+    STOP_IF_UNSAFE( elems , "[refqueue_unsafe_str] allocation error (render str)" );
 
     strncpy( curr , start , slen );
     curr += slen;
@@ -222,7 +238,6 @@ void refqueue_show_in( RefQueue* qs , FILE* stream ){
 //       las referencias de los objetos
 void refqueue_clean( RefQueue* qs ){
     RefQueue* self    = qs;
-    void (*freeObj)() = self->free? self->free : free;
     pthread_mutex_lock( &self->lock );
     while( !refqueue_unsafe_empty(self) ){
         refqueue_unsafe_get(self); // result ignored. reference thrown
@@ -230,10 +245,10 @@ void refqueue_clean( RefQueue* qs ){
     pthread_mutex_unlock( &self->lock );
 }
 
+// NOTE: Elimina los nodos y libera las referencias de los objetos
 void refqueue_destroy( RefQueue* qs ){
     RefQueue* self    = qs;
     void (*freeObj)() = self->free? self->free : free;
-    void*     item;
     pthread_mutex_lock( &self->lock );
     while( !refqueue_unsafe_empty(self) ){
         (*freeObj)( refqueue_unsafe_get(self) );
@@ -241,3 +256,4 @@ void refqueue_destroy( RefQueue* qs ){
     pthread_mutex_unlock( &self->lock );
 }
 
+#undef IS_SAFE_PTR

--- a/RefQueue.c
+++ b/RefQueue.c
@@ -68,13 +68,13 @@ void refqueue_init( RefQueue* qs         ,
 }
 
 // Modelo: Productor-Consumidor:
-void refqueue_put( RefQueue* qs , void* elem ){
+void refqueue_put( RefQueue* qs , void* item ){
     RefQueue* self = qs;
     // |> Begin Critical Region:
     pthread_mutex_lock( &self->lock );
 
     // Unsafe operations:
-    refqueue_unsafe_put( self , elem );
+    refqueue_unsafe_put( self , item );
     pthread_cond_signal( &self->has_item );  // Wake up only a thread
 
     // |> End Critical Region:

--- a/RefQueue.h
+++ b/RefQueue.h
@@ -64,9 +64,9 @@ int    refqueue_unsafe_empty( RefQueue* qs );
 /// @fn void refqueue_singleton( RefQueue* qs )
 /// @brief Crea una cola de referencias trivial.
 /// @param qs Cola a inicializar.
-/// @see refqueue_init.
 /// @details Inicializa una cola de referencias sin protocolos de liberación de memoria dinámica ni
 //           protocolos para mostrar los elementos de la misma.
+/// @see refqueue_init.
 
 /// @fn void refqueue_init( RefQueue* qs , void (*free)(void*) , char* (*str) (void*) )
 /// @brief Inicializa una cola de referencias.
@@ -91,10 +91,10 @@ int    refqueue_unsafe_empty( RefQueue* qs );
 /// @brief Intenta extraer un elemento de la cola.
 /// @param qs Cola objetivo.
 /// @return la referencia del objeto en caso de exito. NULL en caso contrario.
-/// @see refqueue_get.
 /// @details Similar a refqueue_get. retorna NULL y se establece a errno = EBUSY cuando la cola está
 //           vacía. Se puede utilizar para extraer elementos de manera segura y manejar los errores
 //           cuando sea necesario.
+/// @see refqueue_get.
 
 /// @fn void refqueue_clean( RefQueue* qs )
 /// @brief Elimina todas las referencias de la cola.
@@ -106,8 +106,8 @@ int    refqueue_unsafe_empty( RefQueue* qs );
 /// @fn void refqueue_destroy( RefQueue* qs )
 /// @brief Libera todas las referencias de la cola.
 /// @param qs Cola objetivo.
-/// @see refqueue_clean
 /// @details Aplica el protocolo de liberación en todos los elementos de la cola y la deja vacía.
+/// @see refqueue_clean
 
 /// @fn char* refqueue_str( RefQueue* qs )
 /// @brief Obtiene la representación de la cola como cadena.
@@ -119,8 +119,8 @@ int    refqueue_unsafe_empty( RefQueue* qs );
 /// @brief Imprime la cola en un archivo.
 /// @param qs Cola objetivo.
 /// @param stream flujo de caracteres objetivo.
-/// @see refqueue_str.
 /// @details Muestra la cola en un archivo. Útil durante las tareas de depuración.
+/// @see refqueue_str.
 
 /// @fn size_t refqueue_unsafe_len( RefQueue* qs )
 /// @brief Obtiene la longitud de la cola.

--- a/RefQueue.h
+++ b/RefQueue.h
@@ -31,6 +31,7 @@ typedef struct RefQueue {
     char* (*str)( void* e );
 } RefQueue;
 
+void   refqueue_singleton( RefQueue* qs );
 void   refqueue_init   ( RefQueue* qs , void  (*free)(void*) ,
                                         char* (*str) (void*) );
 // Operaciones Atómicas:
@@ -39,12 +40,11 @@ void*  refqueue_get    ( RefQueue* qs );
 void*  refqueue_tryget ( RefQueue* qs );    // retorna NULL y errno = EBUSY si qs está vacío.
 void   refqueue_clean  ( RefQueue* qs );    // Just uses pop.
 void   refqueue_destroy( RefQueue* qs );    // Uses free.
-char*  refqueue_str    ( RefQueue* qs );      // New string must be freed.
+char*  refqueue_str    ( RefQueue* qs );    // New string must be freed.
 void   refqueue_show_in( RefQueue* qs , FILE* stream );
 
 // Operaciones No-Atómicas:
 size_t refqueue_unsafe_len  ( RefQueue* qs );
 int    refqueue_unsafe_empty( RefQueue* qs );
-void*  refqueue_unsafe_last ( RefQueue* xs , void* item );
 
 #endif

--- a/RefQueue.h
+++ b/RefQueue.h
@@ -1,3 +1,12 @@
+/**
+ * @file RefQueue.h
+ * @brief Define el tipo de datos RefQueue, que puede ser usado para
+ *        sincronizar múltiples hilos mediante el paso de referencias a objetos.
+ * @author Gabriel Peraza
+ * @version 1.0.0.0
+ * @date 2021-02-01
+ */
+
 #ifndef __QUEUE__H__
 #define __QUEUE__H__
 
@@ -11,27 +20,31 @@
 // DEPENDIENTE DE UNIX:
 #include <pthread.h>
 
+/// @brief Almacena las referencias de cada objeto dentro del tipo RefQueue.
 typedef struct _LNode {
-    void*          item;
-    struct _LNode* next;
+    void*          item;    ///< Referencia al objeto del nodo.
+    struct _LNode* next;    ///< Referencia al siguiente nodo de la cola.
 } _LNode;
 
-enum Ord { LT = -1 , EQ = 0 , GT = 1 };
-
+/// @brief Estructura FIFO general, con operaciones atómicas.
 typedef struct RefQueue {
-    _LNode* head;
-    _LNode* last;
-    size_t  n;
+    _LNode* head;               ///< Primer elemento de la Cola.
+    _LNode* last;               ///< Ultimo elemento de la Cola.
+    size_t  n;                  ///< Número de elementos actualmente en la cola.
 
     // Atomicidad:
-    pthread_mutex_t lock;
-    pthread_cond_t  has_item;
+    pthread_mutex_t lock;       ///< Asegura la exclusión mutua.
+    pthread_cond_t  has_item;   ///< Hace que los hilos esperen hasta que la cola contenga algún elemento.
 
-    void  (*free)( void* e );
-    char* (*str)( void* e );
+    void  (*free)( void* e );   ///< Protocolo para liberar los objetos de la cola, el cual puede ser **NULL**.
+    char* (*str)( void* e );    ///< Protocolo para representar los objetos como cadena, el cual puede ser **NULL**.
 } RefQueue;
 
 void   refqueue_singleton( RefQueue* qs );
+/// @brief Inicializa una cola de referencias.
+/// @param qs Cola a inicializar.
+/// @param free Protocolo de liberación de los elementos de la cola.
+/// @param str Protocolo para generar la representación de los elementos como cadena de caracteres.
 void   refqueue_init   ( RefQueue* qs , void  (*free)(void*) ,
                                         char* (*str) (void*) );
 // Operaciones Atómicas:
@@ -39,12 +52,86 @@ void   refqueue_put    ( RefQueue* qs , void* item );
 void*  refqueue_get    ( RefQueue* qs );
 void*  refqueue_tryget ( RefQueue* qs );    // retorna NULL y errno = EBUSY si qs está vacío.
 void   refqueue_clean  ( RefQueue* qs );    // Just uses pop.
-void   refqueue_destroy( RefQueue* qs );    // Uses free.
+void   refqueue_destroy( RefQueue* qs );    // Uses free. TODO: Renombrar a refqueue_freeobjs()
+                                            // TODO: Agregar refqueue_destroy() para liberar todo.
 char*  refqueue_str    ( RefQueue* qs );    // New string must be freed.
 void   refqueue_show_in( RefQueue* qs , FILE* stream );
 
 // Operaciones No-Atómicas:
 size_t refqueue_unsafe_len  ( RefQueue* qs );
 int    refqueue_unsafe_empty( RefQueue* qs );
+
+/// @fn void refqueue_singleton( RefQueue* qs )
+/// @brief Crea una cola de referencias trivial.
+/// @param qs Cola a inicializar.
+/// @see refqueue_init.
+/// @details Inicializa una cola de referencias sin protocolos de liberación de memoria dinámica ni
+//           protocolos para mostrar los elementos de la misma.
+
+/// @fn void refqueue_init( RefQueue* qs , void (*free)(void*) , char* (*str) (void*) )
+/// @brief Inicializa una cola de referencias.
+/// @param qs Cola a inicializar.
+/// @param free Protocolo de liberación de los elementos de la cola.
+/// @param str Protocolo para generar la representación de los elementos como cadena de caracteres.
+
+/// @fn void refqueue_put( RefQueue* qs , void * item )
+/// @brief Inserta un objeto en la cola.
+/// @param qs Cola destino.
+/// @param item Referencia al objeto a insertar.
+/// @details Usa la exclusión mutua para insertar la referencia del objeto al final de la cola.
+
+/// @fn void* refqueue_get( RefQueue* qs )
+/// @brief Extrae un elemento de la cola de manera atómica.
+/// @param qs Cola objetivo.
+/// @return la referencia del objeto en caso de exito.
+/// @details Usa la exclusión mutua para extraer la referencia del objeto que está en el frente de la cola.
+///          **El hilo invocador quedará bloqueado hasta que sea insertado algún elemento dentro de qs**.
+
+/// @fn void* refqueue_tryget( RefQueue* qs )
+/// @brief Intenta extraer un elemento de la cola.
+/// @param qs Cola objetivo.
+/// @return la referencia del objeto en caso de exito. NULL en caso contrario.
+/// @see refqueue_get.
+/// @details Similar a refqueue_get. retorna NULL y se establece a errno = EBUSY cuando la cola está
+//           vacía. Se puede utilizar para extraer elementos de manera segura y manejar los errores
+//           cuando sea necesario.
+
+/// @fn void refqueue_clean( RefQueue* qs )
+/// @brief Elimina todas las referencias de la cola.
+/// @param qs Cola objetivo.
+//  @details Las referencias de la cola son descartadas. Es particularmente útil cuando los elementos de
+//           qs fueron reservados de forma estática.
+
+// TODO: Modificar para simplemente destruir el semáforo interno y la variable de condición.
+/// @fn void refqueue_destroy( RefQueue* qs )
+/// @brief Libera todas las referencias de la cola.
+/// @param qs Cola objetivo.
+/// @see refqueue_clean
+/// @details Aplica el protocolo de liberación en todos los elementos de la cola y la deja vacía.
+
+/// @fn char* refqueue_str( RefQueue* qs )
+/// @brief Obtiene la representación de la cola como cadena.
+/// @param qs Cola objetivo.
+/// @return Representación de la cola en el formato: "[ e1 , e2 , ... ]" 
+/// @details Convierte a cadena cada elemento de la cola y los junta en una sola cadena.
+
+/// @fn void refqueue_show_in( RefQueue* qs , FILE* stream )
+/// @brief Imprime la cola en un archivo.
+/// @param qs Cola objetivo.
+/// @param stream flujo de caracteres objetivo.
+/// @see refqueue_str.
+/// @details Muestra la cola en un archivo. Útil durante las tareas de depuración.
+
+/// @fn size_t refqueue_unsafe_len( RefQueue* qs )
+/// @brief Obtiene la longitud de la cola.
+/// @param qs Cola objetivo.
+/// @warning No es Thread-Safe.
+/// @return longitud de la cola. No se asegura la exclusión mutua.
+
+/// @fn int refqueue_unsafe_empty( RefQueue* qs )
+/// @brief Verifica si la cola está vacía.
+/// @param qs Cola objetivo.
+/// @warning No es Thread-Safe.
+/// @return Lógico. No se asegura la exclusión mutua.
 
 #endif

--- a/ejemplos/quick_shared_queue.c
+++ b/ejemplos/quick_shared_queue.c
@@ -13,8 +13,8 @@ RefQueue cola;
 typedef struct pair { char* name; unsigned sleep_time; } pair;
 
 static char* show_dynamic_int( void* int_ptr );
-void* productor ( void* thread_name );
-void* consumidor( void* thread_name );
+void* productor ( void* pair_info );
+void* consumidor( void* pair_info );
 
 void* productor( void* pair_info ){
     pair*    p    = (pair*) pair_info;

--- a/ejemplos/refmap-allocate.c
+++ b/ejemplos/refmap-allocate.c
@@ -1,0 +1,150 @@
+#include "../RefMap.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int int_cmp( void* ptr_a , void* ptr_b ){
+    int a = *((int*) ptr_a) , b = *((int*) ptr_b);
+    return ( ( a < b )?    -1 :
+                ( a == b )? 0 : 1 );
+}
+
+// int cast_cmp( void* ptr_a , void* ptr_b ){
+//     int a = (int) ptr_a , b = (int) ptr_b;
+//     return ( ( a < b )?    -1 : ( a == b )? 0 : 1 );
+// }
+
+void* int_cpy( void* int_ptr ){
+    int* value = (int*) int_ptr;
+    int* newv  = malloc( sizeof(int) );
+    *newv = *value;
+    return newv;
+}
+
+void print_empty_state( RefMap* m ){
+    printf( "[RefMap] Is empty?: %s\n" , refmap_unsafe_empty(m)? "yes" : "no" );
+    printf( "[RefMap] size:      %d\n" , refmap_unsafe_size(m) );
+}
+
+void unsafe_lookup( RefMap* map , int k ){
+    printf( "Does it have %d? %s\n" , k , refmap_unsafe_contains( map , &k )? "yes" : "no" );
+}
+
+void unsafe_put( RefMap* map , int k , int* value ){
+    //printf( "Putting (%d,%d) into map.\n" , k , *value );
+    refmap_put( map , &k , value );
+}
+
+// void refmap_put_int( RefMap* m , int key , int value ){
+//     refmap_put( m , (void*) key , (void*) value );
+// }
+
+void int_debug( void* int_value ){
+    int* n = int_value;
+    fprintf( stderr , "%d" , *n  );
+}
+
+int main(){
+    int keys[] = {  1,  2,  3,  4,  9};
+    int vals[] = {-10,-20, 30, 44, 99};
+    int n      = sizeof(keys) / sizeof(int);
+    RefMap map;
+    int skip  = 1;
+    int skip2 = 1;
+    if( !skip ){
+        printf( "-- Test 1: Insert Values --\n" );
+        refmap_init( &map , &int_cmp , int_cpy , NULL );
+        print_empty_state(&map);
+        putc( '\n' , stdout );
+
+        for( int i = 0 ; i < n ; i += 1 ){
+            refmap_put( &map , keys + i , vals + i );
+        }
+
+        int* reference;
+        for( int i = 0 ; i < n ; i += 1 ){
+            reference = refmap_unsafe_get(&map , keys + i);
+            printf( "(Key: Value) -> (%d : %p [%d] ),\n" , keys[i] , reference , *reference );
+        }
+        putc( '\n' , stdout );
+
+        print_empty_state(&map);
+        refmap_destroy( &map );
+
+        putc( '\n' , stdout );
+        printf( "-- Test 2: Failures on search --\n" );
+
+        refmap_init( &map , &int_cmp , int_cpy , NULL );
+        refmap_put( &map , keys + 0 , vals + 0 ); //1
+        refmap_put( &map , keys + 3 , vals + 3 ); //4
+
+        unsafe_lookup( &map , 15  );
+        unsafe_lookup( &map , 1   );
+        unsafe_lookup( &map , 33  );
+        unsafe_lookup( &map , -32 );
+        unsafe_lookup( &map ,  99 );
+        unsafe_lookup( &map , -10 );
+        unsafe_lookup( &map ,  -4 );
+        unsafe_lookup( &map ,   4 );
+
+        refmap_clear( &map );
+    }
+    if( !skip2 ){
+        refmap_init( &map , &int_cmp , int_cpy , NULL );
+        printf( "-- Test 3: Simple Insertions/Deletions: --\n" );
+        //int limit = 4;
+        int limit = 5;
+        for( int i = limit; i >= 1 ; i -= 1){
+            unsafe_put( &map , i , vals );
+        }
+        printf( "Inserted: %d elements in the map.\n" , limit );
+        refmap_debug( &map , 1 , int_debug , int_debug );
+        refmap_destroy( &map );
+        printf( "Deleted: %d elements in the map.\n" , limit );
+    }
+
+    refmap_init( &map , &int_cmp , int_cpy , NULL );
+    printf( "\n-- Test 4: Intensive Insertions/Deletions: --\n" );
+    printf( " > Size of Keys (int):    %d Bytes.\n" , sizeof(int)    );
+    printf( " > Size of NodeRB:        %d Bytes.\n" , sizeof(NodeRB) );
+    printf( "-- Press Enter to continue -- " );
+    fgetc( stdin );
+
+    int limit = 1000000;      // Before used 93 MiB, now uses 78MiB.
+    // int limit = 10000000;  // Before used 916 MiB, now uses 764MiB.
+    // int limit = 10000;        // uses 2 MiB.
+    // int limit = 100000;     // Before used 11MiB, now uses 9 MiB.
+
+    int bytes  = limit * sizeof(NodeRB);
+    int kbytes = limit * sizeof(int);
+    int total  = bytes + kbytes;
+    for( int i = limit; i >= 1 ; i -= 1){
+        unsafe_put( &map , i , vals );
+    }
+    printf( "Inserted: %d elements in the map.\n" , limit );
+    printf( "Aproximated RAW size (only Nodes):\n"
+            "    %d Bytes\n"
+            "    %d KiB\n"
+            "    %d MiB\n" , bytes , bytes / 1024 , bytes / (1024*1024) );
+    printf( "Aproximated Keys size:\n"
+            "    %d Bytes\n"
+            "    %d KiB\n"
+            "    %d MiB\n" , kbytes , kbytes / 1024 , kbytes / (1024*1024) );
+    printf( "Aproximated RefMap Size:\n"
+            "    %d Bytes\n"
+            "    %d KiB\n"
+            "    %d MiB\n" , total , total / 1024 , total / (1024*1024) );
+    printf( "-- Press Enter to continue -- " );
+    fgetc( stdin );
+
+    refmap_destroy( &map );
+    printf( "Deleted: %d elements in the map.\n" , limit );
+
+    // Warnings:
+    // refmap_init( &map , &cast_cmp );
+    // refmap_put_int( &map , 100 , 70 );
+    // int k = refmap_unsafe_get( &map , 100 );
+    // printf( "(Key: Value) -> (%d : [%d] ),\n" , 100 , k );
+    // refmap_destroy( &map );
+    return 0;
+}

--- a/ejemplos/refmap-debug.c
+++ b/ejemplos/refmap-debug.c
@@ -1,0 +1,58 @@
+#include "../RefMap.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int char_cmp( void* ptr_a , void* ptr_b ){
+    char a = *((char*) ptr_a) , b = *((char*) ptr_b);
+    return ( ( a < b )?    -1 :
+                ( a == b )? 0 : 1 );
+}
+
+void* char_cpy( void* int_ptr ){
+    char* value = int_ptr;
+    char* newv  = malloc( sizeof(char) );
+    *newv = *value;
+    return newv;
+}
+
+void print_empty_state( RefMap* m ){
+    printf( "[RefMap] Is empty?: %s\n" , refmap_unsafe_empty(m)? "yes" : "no" );
+    printf( "[RefMap] size:      %d\n" , refmap_unsafe_size(m) );
+}
+
+void unsafe_put( RefMap* map , char k , char* value ){
+    refmap_put( map , &k , value );
+}
+
+void char_debug( void* char_value ){
+    char* c = char_value;
+    fprintf( stderr , "%c" , *c  );
+}
+
+int main(){
+    char word[] = "SEARCHXMPL";
+    char* w = word;
+    int i = 0;
+
+    RefMap map;
+    refmap_init( &map , &char_cmp, char_cpy , NULL );
+    printf( "-- Test: Verification: --\n" );
+    while( *w != '\0' ){
+        unsafe_put( &map , *w , w );
+        //refmap_debug( &map , 1 , &char_debug , &char_debug );
+        //fprintf( stderr , "Inserted %c ------\n" , *w );
+        //refmap_debug( &map , 1 , NULL , NULL );
+        //fprintf( stderr , "------------------\n\n" , *w );
+        //
+        w += 1;
+        i += 1;
+    }
+    fprintf( stderr , "------ Delete test ------\n" , *w );
+    refmap_debug( &map , 1 , &char_debug , &char_debug );
+
+    printf( "Inserted: %d elements in the map.\n" , i );
+    refmap_destroy( &map );
+    printf( "Deleted: %d elements in the map.\n" ,  i );
+    return 0;
+}

--- a/ejemplos/shared_queue.c
+++ b/ejemplos/shared_queue.c
@@ -12,8 +12,8 @@ RefQueue cola;
 typedef struct pair { char* name; unsigned sleep_time; } pair;
 
 static char* show_dynamic_int( void* int_ptr );
-void* productor ( void* thread_name );
-void* consumidor( void* thread_name );
+void* productor ( void* pair_info );
+void* consumidor( void* pair_info );
 
 void* productor( void* pair_info ){
     pair*    p    = (pair*) pair_info;

--- a/ejemplos/simple_queue.c
+++ b/ejemplos/simple_queue.c
@@ -18,7 +18,7 @@ int main(){
     }
 
     printf( "[*1] Prueba con memoria Dinámica:\n"
-            "     Cola de Referencias Opaca (long %d): " , MAX );
+            "     Cola de Referencias Opaca (longitud %d): " , MAX );
     refqueue_show_in( &cola , stdout );
     printf( "\n" );
 
@@ -39,7 +39,7 @@ int main(){
     refqueue_init( &cola , NULL , NULL );
     refqueue_put( &cola , (void*) 99 ); // Cast explícito de una constante a un apuntador void
     printf( "[*2] Prueba mediante el uso de una constante:\n"
-            "     Cola de Referencias Opaca con una constante (long %d): " , 1 );
+            "     Cola de Referencias Opaca con una constante (longitud %d): " , 1 );
     refqueue_show_in( &cola , stdout );
     printf( "\n" );
     refqueue_clean( &cola );    // Sólo descarta las referencias que estaban en la cola.
@@ -51,7 +51,7 @@ int main(){
     refqueue_put( &cola , (void*) 49 ); // Cast explícito de una constante a un apuntador void
     refqueue_put( &cola , (void*) 35 ); // Cast explícito de una constante a un apuntador void
     printf( "[*3] Prueba con varias constantes:\n"
-            "     Cola de Referencias Opaca con varias constantes (long %d): " , 3 );
+            "     Cola de Referencias Opaca con varias constantes (longitud %d): " , 3 );
     refqueue_show_in( &cola , stdout );
     printf( "\n" );
     refqueue_clean( &cola );    // Sólo descarta las referencias que estaban en la cola.

--- a/ejemplos/tryget_queue.c
+++ b/ejemplos/tryget_queue.c
@@ -14,8 +14,9 @@ RefQueue cola;
 typedef struct pair { char* name; unsigned sleep_time; } pair;
 
 static char* show_dynamic_int( void* int_ptr );
-void* productor ( void* thread_name );
-void* consumidor( void* thread_name );
+void* productor ( void* pair_info );
+void* consumidor( void* pair_info );
+void* konsumidor( void* pair_info );
 
 void* productor( void* pair_info ){
     pair*    p    = (pair*) pair_info;

--- a/makefile
+++ b/makefile
@@ -9,10 +9,11 @@ endif
 # Variables de compilación
 CC	   := gcc
 DEBUG  := -g -O0
-COMMON := -pthread $(DEBUG)
+COMMON := -pthread $(DEBUG) -lm
 LIBFLG := -c
 TARGET := a.$(EXT)
 MFILES := hospitales.c
+EXAMPL := ejemplos
 
 .PHONY: all
 
@@ -22,13 +23,27 @@ run:
 	@echo "Ejecutando Programa..."
 	@command ./$(TARGET)
 
+# Genera casos de pruebas para los tipos de datos:
+tests: queue-tests refmap-tests
 
+# Genera los casos de prueba para el tipo "Cola de Referencias":
 queue-tests: generic-queue
-	@echo Generando ejemplos de uso para la Cola de Referencias...
-	$(CC) $(COMMON) ejemplos/simple_queue.c RefQueue.o -o ejemplos/simple_queue.$(EXT)
-	$(CC) $(COMMON) ejemplos/shared_queue.c RefQueue.o -o ejemplos/shared_queue.$(EXT)
-	$(CC) $(COMMON) ejemplos/quick_shared_queue.c RefQueue.o -o ejemplos/quick_shared_queue.$(EXT)
-	$(CC) $(COMMON) ejemplos/tryget_queue.c RefQueue.o -o ejemplos/tryget_queue$(EXT)
+	@echo [Q] Generando ejemplos de uso para la Cola de Referencias...
+	$(CC) $(COMMON) $(EXAMPL)/simple_queue.c RefQueue.o -o $(EXAMPL)/simple_queue.$(EXT)
+	$(CC) $(COMMON) $(EXAMPL)/shared_queue.c RefQueue.o -o $(EXAMPL)/shared_queue.$(EXT)
+	$(CC) $(COMMON) $(EXAMPL)/quick_shared_queue.c RefQueue.o -o $(EXAMPL)/quick_shared_queue.$(EXT)
+	$(CC) $(COMMON) $(EXAMPL)/tryget_queue.c RefQueue.o -o $(EXAMPL)/tryget_queue.$(EXT)
+	@echo
 
+# Genera los casos de prueba para el tipo "Mapa de Referencias":
+refmap-tests: refmap
+	@echo [M] Generando ejemplos de uso para el Mapa de Referencias...
+	$(CC) $(COMMON) $(EXAMPL)/refmap-allocate.c RefMap.o -o $(EXAMPL)/refmap-allocate.$(EXT)
+	$(CC) $(COMMON) $(EXAMPL)/refmap-debug.c RefMap.o -o $(EXAMPL)/refmap-debug.$(EXT)
+	@echo
+
+# Genera los Archivos Objetos de los Tipos de datos:
 generic-queue:
 	$(CC) $(COMMON) $(LIBFLG) RefQueue.c RefQueue.h
+refmap:
+	$(CC) $(COMMON) $(LIBFLG) RefMap.c RefMap.h

--- a/makefile
+++ b/makefile
@@ -1,9 +1,19 @@
+# Extensión según el sistema operativo:
+EXT	   :=
+ifeq ($(OS),Windows_NT)
+	EXT +=exe
+else
+	EXT +=out
+endif
+
+# Variables de compilación
 CC	   := gcc
 DEBUG  := -g -O0
 COMMON := -pthread $(DEBUG)
 LIBFLG := -c
-TARGET := a.out
+TARGET := a.$(EXT)
 MFILES := hospitales.c
+
 .PHONY: all
 
 all:
@@ -15,10 +25,10 @@ run:
 
 queue-tests: generic-queue
 	@echo Generando ejemplos de uso para la Cola de Referencias...
-	$(CC) $(COMMON) ejemplos/simple_queue.c RefQueue.o -o ejemplos/simple_queue.out
-	$(CC) $(COMMON) ejemplos/shared_queue.c RefQueue.o -o ejemplos/shared_queue.out
-	$(CC) $(COMMON) ejemplos/quick_shared_queue.c RefQueue.o -o ejemplos/quick_shared_queue.out
-	$(CC) $(COMMON) ejemplos/tryget_queue.c RefQueue.o -o ejemplos/tryget_queue.out
+	$(CC) $(COMMON) ejemplos/simple_queue.c RefQueue.o -o ejemplos/simple_queue.$(EXT)
+	$(CC) $(COMMON) ejemplos/shared_queue.c RefQueue.o -o ejemplos/shared_queue.$(EXT)
+	$(CC) $(COMMON) ejemplos/quick_shared_queue.c RefQueue.o -o ejemplos/quick_shared_queue.$(EXT)
+	$(CC) $(COMMON) ejemplos/tryget_queue.c RefQueue.o -o ejemplos/tryget_queue$(EXT)
 
 generic-queue:
 	$(CC) $(COMMON) $(LIBFLG) RefQueue.c RefQueue.h


### PR DESCRIPTION
**Resumen de Cambios:**
- Nuevo Tipo de Dato: RefMap, un mapa o diccionario que puede almacenar claves y valores genéricos.
- Se ha ha añadido documentación tipo Doxygen dentro de RefMap y RefQueue.
- Hay nuevos ejemplos que muestran cómo utilizar el nuevo tipo de Dato.
- Las extensiones de los ejecutables dependen del sistema operativo (.exe para Windows, .out para UNIX/Linux)

**NOTE**: RefMap debe ser compilado antes de ser utilizado por otras librerías. Requiere el uso del flag -lm al momento de compilar.