### PR TITLE
Mejoras de Rendimiento en RefMap y RefQueue

### DIFF
--- a/RefMap.c
+++ b/RefMap.c
@@ -585,7 +585,7 @@ void refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) , 
         ured    = red;
         unormal = normal;
     } else
-        ublack = ured = unormal;
+        ublack = ured = unormal = "";
     fprintf( stderr , "%s" , unormal );
     debug( t->root , 4 , 4 ,
            ublack , ured , unormal ,
@@ -598,10 +598,8 @@ void refmap_clear( RefMap* t ){
     // <| BEGIN CRITICAL REGION
     pthread_mutex_lock( &self->lock );
 
-    void* k , *outk;
     while( !refmap_unsafe_empty(t) ){
-        k    = t->root->key;
-        refmap_unsafe_delete( t , k );
+        refmap_unsafe_deleteMin( t );
     }
 
     // <| END CRITICAL REGION
@@ -613,12 +611,8 @@ void refmap_destroy( RefMap* t ){
     // <| BEGIN CRITICAL REGION
     pthread_mutex_lock( &self->lock );
 
-    void* k , *outk;
-    // BUG: when deletes the 6th elements, it delete twice, idk why, I must see what happens!
     while( !refmap_unsafe_empty(t) ){
-        //refmap_debug(t);
-        k    = t->root->key;
-        refmap_unsafe_delete( t , k );
+        refmap_unsafe_deleteMin( t );
     }
     // <| END CRITICAL REGION
     pthread_mutex_unlock( &self->lock );

--- a/RefQueue.h
+++ b/RefQueue.h
@@ -52,8 +52,8 @@ void   refqueue_put    ( RefQueue* qs , void* item );
 void*  refqueue_get    ( RefQueue* qs );
 void*  refqueue_tryget ( RefQueue* qs );    // retorna NULL y errno = EBUSY si qs está vacío.
 void   refqueue_clean  ( RefQueue* qs );    // Just uses pop.
-void   refqueue_destroy( RefQueue* qs );    // Uses free. TODO: Renombrar a refqueue_freeobjs()
-                                            // TODO: Agregar refqueue_destroy() para liberar todo.
+void   refqueue_destroy( RefQueue* qs );
+void   refqueue_deallocateAll( RefQueue* qs );   // Applies free() to each object and q gets empty.
 char*  refqueue_str    ( RefQueue* qs );    // New string must be freed.
 void   refqueue_show_in( RefQueue* qs , FILE* stream );
 
@@ -102,12 +102,21 @@ int    refqueue_unsafe_empty( RefQueue* qs );
 //  @details Las referencias de la cola son descartadas. Es particularmente útil cuando los elementos de
 //           qs fueron reservados de forma estática.
 
-// TODO: Modificar para simplemente destruir el semáforo interno y la variable de condición.
 /// @fn void refqueue_destroy( RefQueue* qs )
+/// @brief Elimina todas las referencias de la cola.
+/// @param qs Cola objetivo.
+/// @details Descarta todas las referencias de la cola y destruye los elementos usados
+//           para asegurar la exclusión mututa. *La cola debe inicializarse otra vez para
+//           utilizarla.*
+/// @see refqueue_clean
+
+/// @fn void refqueue_deallocateAll( RefQueue* qs )
 /// @brief Libera todas las referencias de la cola.
 /// @param qs Cola objetivo.
 /// @details Aplica el protocolo de liberación en todos los elementos de la cola y la deja vacía.
-/// @see refqueue_clean
+/// @warning Sólo aplicar cuando se está seguro de que los elementos de la cola han
+//           sido reservados con memoria dinámica.
+/// @see refqueue_destroy
 
 /// @fn char* refqueue_str( RefQueue* qs )
 /// @brief Obtiene la representación de la cola como cadena.

--- a/ejemplos/simple_queue.c
+++ b/ejemplos/simple_queue.c
@@ -32,7 +32,7 @@ int main(){
     free( var );
 
     // Totalmente requerido en este caso!
-    refqueue_destroy( &cola );  // Elimina los objetos de la cola.
+    refqueue_deallocateAll( &cola );  // Elimina los objetos de la cola.
 
 
     // Prueba Con una constante (2)


### PR DESCRIPTION
**Resumen de Cambios:**
- Mejora de rendimiento dentro de las rutinas destroy de ambos tipos de datos.
- Ahora, `refqueue_destroy` sólo descarta los elementos de la cola y destruye elementos internos para asegurar la exclusión mutua.
- Se ha añadido la rutina `refqueue_deallocateAll` que aplica la rutina de liberación a cada elemento de la cola, y luego destruye las estructuras que aseguran la exclusión mutua.
- Luego de aplicar alguno de esos dos metodos se necesita llamar a `refqueue_init` o a `refqueue_singleton` para usar la cola nuevamente.