### PR TITLE
Primitivas de bloqueo dentro de la API de RefMap

### DIFF
--- a/Tipos/RefMap.c
+++ b/Tipos/RefMap.c
@@ -252,6 +252,9 @@ void refmap_init( RefMap* t                            ,
     STOP_IF_UNSAFE( t->callstack , "refmap_init: Unable to build call stack." );
 }
 
+void*  refmap_unsafe_lock  ( RefMap* t ){ pthread_mutex_lock( &t->lock );   }
+int    refmap_unsafe_unlock( RefMap* t ){ pthread_mutex_unlock( &t->lock ); }
+
 int refmap_unsafe_empty( RefMap* t ){ return t->root == NULL; }
 int refmap_unsafe_size ( RefMap* t ){ return nodeSize( t->root ); }
 

--- a/Tipos/RefMap.h
+++ b/Tipos/RefMap.h
@@ -4,7 +4,7 @@
  *        preservar el orden de los elementos al proporcionar llaves
  *        de búsqueda.
  * @author Gabriel Peraza
- * @version 1.0.0.0
+ * @version 1.2.0.0
  * @date 2021-02-08 */
 
 // Estándar usado: __PAQUETE__SUBPAQUETE__ ... __NOMBRE_MODULO_
@@ -108,12 +108,15 @@ void*  refmap_extract_min_if_key( RefMap* t , int (*predicate)(void*) );
 //          y dicha clave cumpla con el predicado.
 void*  refmap_extract_max_if_key( RefMap* t , int (*predicate)(void*) );
 
-void*  refmap_unsafe_get   ( RefMap* t , void* key );       // ()
-int    refmap_unsafe_empty ( RefMap* t );                   // ()
-int    refmap_unsafe_size  ( RefMap* t );                   // ()
-int    refmap_unsafe_contains ( RefMap* t , void* key );    // ()
-void*  refmap_unsafe_minkey( RefMap* t );                      // ()
-void*  refmap_unsafe_maxkey( RefMap* t );                      // ()
+void*  refmap_unsafe_lock  ( RefMap* t );
+int    refmap_unsafe_unlock( RefMap* t );
+
+void*  refmap_unsafe_get   ( RefMap* t , void* key );
+int    refmap_unsafe_empty ( RefMap* t );
+int    refmap_unsafe_size  ( RefMap* t );
+int    refmap_unsafe_contains ( RefMap* t , void* key );
+void*  refmap_unsafe_minkey( RefMap* t );
+void*  refmap_unsafe_maxkey( RefMap* t );
 /// @brief Muestra el mapa en stderr.
 /// @param t Mapa objetivo.
 /// @param use_ascii_color Lógico. si es 0, no muestra colores. si es 1 muestra colores. (Formato Unix)
@@ -151,6 +154,11 @@ void   refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) 
 /// @returns Referencia del valor asociado con key. Si no se encuentra key, retorna NULL.
 /// @see refmap_extract
 
+/// @fn void* refmap_extract_max( RefMap* t )
+/// @brief Extrae el valor asociado para la clave más grande del mapa.
+/// @param t Mapa objetivo.
+/// @returns Referencia del valor asociado con key. Si no se encuentra key, retorna NULL.
+/// @see refmap_extract
 
 /// @fn void refmap_delete( RefMap* t , void* key )
 /// @brief Remueve el valor asociado para la clave proporcionada.
@@ -160,6 +168,11 @@ void   refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) 
 
 /// @fn void refmap_deleteMin( RefMap* t )
 /// @brief Remueve el valor asociado para la clave más pequeña del mapa.
+/// @param t Mapa objetivo.
+/// @see refmap_delete
+//
+/// @fn void refmap_deleteMax( RefMap* t )
+/// @brief Remueve el valor asociado para la clave más grande del mapa.
 /// @param t Mapa objetivo.
 /// @see refmap_delete
 
@@ -174,6 +187,20 @@ void   refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) 
 /// @details El mapa queda vacío una vez aplicada la operación. Destruye los objetos usados
 ///          para asegurar la exclusión mutua.
 /// @see refmap_clear
+
+/// @fn void* refmap_unsafe_lock( RefMap* t )
+/// @brief Bloquea el semáforo interno de t.
+/// @param t Mapa objetivo.
+/// @warning **DEBE ESTAR SEGURO DE USAR ESTA PRIMITIVA. DEJAR BLOQUEADO EL MAPA PUEDE CAUSAR INTERBLOQUEO**
+/// @details Permite reservar exclusivamente a t. Una vez finalizada todas las operaciones, **debe desbloquear manualmente el mapa**.
+/// @see refmap_unsafe_unlock
+
+/// @fn void* refmap_unsafe_unlock( RefMap* t )
+/// @brief Desbloquea el semáforo interno de t.
+/// @param t Mapa objetivo.
+/// @warning **EL MAPA DEBE ESTAR BLOQUEADO ANTES DE USAR ESTA PRIMITIVA, PUEDE OCURRIR ERRORES DE EJECUCION.**
+/// @details Permite liberar a t, luego de que haber sido reservado con refmap_unsafe_lock.
+/// @see refmap_unsafe_lock
 
 /// @fn void* refmap_unsafe_get( RefMap* t , void* key )
 /// @brief Consulta el valor asociado a la clave proporcionada dentro de un mapa.

--- a/definiciones.h
+++ b/definiciones.h
@@ -1,3 +1,10 @@
+/**
+ * @file definiciones.h
+ * @brief Definiciones de las estructuras y variables globales usadas dentro del programa.
+ * @author Todos
+ * @version 0.0.3.1
+ * @date 2021-03-04
+ */
 #ifndef __DEFINICIONES_H__
 #define __DEFINICIONES_H__
 

--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@
 // SIGUSR1 <-> Llegó el momento de hacer un reporte.
 // SIGINT  <-> Hay que liberar los recursos y finalizar el programa.
 #define NANOSEGUNDOS_EN_SEGUNDOS 1000000000;
+#define ABSOLUTE TIMER_ABSTIME
 #define RELATIVE 0
 
 

--- a/makefile
+++ b/makefile
@@ -2,10 +2,11 @@
 # Elige la extensión del ejecutable según el Sistema Operativo:
 # (para el caso en el que se utilice la librería pthread en windows)
 EXT	   :=
-# Colores: Azul(BL), Rojo(RL),
+# Colores: Azul(BL), Rojo(RL), Verde(GL)
 # 		   Reiniciar Color(RE). Sólo en Unix/Linux.
 RL     :=
 BL     :=
+GL     :=
 RE     :=
 ifeq ($(OS),Windows_NT)
 	EXT +=exe
@@ -13,6 +14,7 @@ else
 	EXT +=out
 	BL  += \u001b[38;5;32m
 	RL  += \u001b[38;5;9m
+	GL  += \u001b[38;5;10m
 	RE  += \u001b[0m
 endif
 # ------------------------------------------------------------------
@@ -36,17 +38,20 @@ TXAMPL := $(TYPES)/$(EXAMPL)
 
 # TODO: Agregar los objetos generados por definiciones y actores
 all: refmap generic-queue
+	@echo -e "$(BL) [@] Generando archivo principal $(GL)($(TARGET))$(BL)...$(RE)"
 	$(CC) $(COMMON) $(OBJS) $(MFILES) -o $(TARGET)
 run:
-	@echo "Ejecutando Programa..."
+	@echo -e "$(BL) [|>] Ejecutando Programa...$(RE)"
 	@command ./$(TARGET)
+	@echo -e "$(GL)Hecho\n$(RE)"
 
 
 # ------------------------------------------------------
 # Crea los archivos de definiciones:
 definiciones: refmap generic-queue
-	@echo [D] Generando definiciones:
+	@echo -e "$(BL) [D] Generando definiciones: $(RE)"
 	$(CC) $(COMMON) $(LIBFLG) definiciones.h definiciones.c
+	@echo -e "$(GL)Hecho\n$(RE)"
 
 
 # ------------------------------------------------------
@@ -55,20 +60,20 @@ tests: queue-tests refmap-tests
 
 # Genera los casos de prueba para el tipo "Cola de Referencias":
 queue-tests: generic-queue
-	@echo [Q] Generando ejemplos de uso para la Cola de Referencias...
+	@echo -e "$(BL) [Q] Generando ejemplos de uso para la Cola de Referencias...$(RE)"
 	$(CC) $(COMMON) $(TXAMPL)/simple_queue.c       RefQueue.o -o $(TXAMPL)/simple_queue.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/shared_queue.c       RefQueue.o -o $(TXAMPL)/shared_queue.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/quick_shared_queue.c RefQueue.o -o $(TXAMPL)/quick_shared_queue.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/tryget_queue.c       RefQueue.o -o $(TXAMPL)/tryget_queue.$(EXT)
-	@echo
+	@echo -e "$(GL)Hecho\n$(RE)"
 
 # Genera los casos de prueba para el tipo "Mapa de Referencias":
 refmap-tests: refmap
-	@echo [M] Generando ejemplos de uso para el Mapa de Referencias...
+	@echo -e "$(BL) [M] Generando ejemplos de uso para el Mapa de Referencias...$(RE)"
 	$(CC) $(COMMON) $(TXAMPL)/refmap-allocate.c  RefMap.o -o $(TXAMPL)/refmap-allocate.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/refmap-debug.c     RefMap.o -o $(TXAMPL)/refmap-debug.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/refmap-debug-max.c RefMap.o -o $(TXAMPL)/refmap-debug-max.$(EXT)
-	@echo
+	@echo -e "$(GL)Hecho\n$(RE)"
 # ------------------------------------------------------
 
 
@@ -79,8 +84,10 @@ refmap-tests: refmap
 # 	>>> Los .o se generan en el archivo raíz.
 # 		Ejemplo: compilar ./$(TYPES)/RefQueue.c --> genera --> ./RefQueue.o
 generic-queue:
+	@echo -e "$(BL) [Q] Creando $(GL)RefQueue$(BL):$(RE)"
 	$(CC) $(COMMON) $(LIBFLG) $(TYPES)/RefQueue.c $(TYPES)/RefQueue.h
 refmap:
+	@echo -e "$(BL) [M] Creando $(GL)RefMap$(BL):$(RE)"
 	$(CC) $(COMMON) $(LIBFLG) $(TYPES)/RefMap.c $(TYPES)/RefMap.h
 # ------------------------------------------------------
 
@@ -90,19 +97,18 @@ refmap:
 # ------------------------------------------------------
 # Métodos para limpiar los rastros de las compilaciones:
 clean-all: clean-types clean-root
-	@echo Listo
-	@echo
+	@echo -e "$(GL)Hecho\n$(RE)"
 
 # Limpieza:
 clean-types:
-	@echo Eliminando archivos ejecutables de $(TXAMPL)
+	@echo -e "$(RL)[!] Eliminando archivos ejecutables de $(TXAMPL)$(RE)"
 	rm -f $(TXAMPL)/*.$(EXT)
-	@echo Eliminando archivos objetos de $(TYPES)
+	@echo -e "$(RL)[!] Eliminando archivos objetos de $(TYPES)$(RE)"
 	rm -f $(TYPES)/*.h.gch
 	@echo
 
 clean-root:
-	@echo Eliminando archivos objetos de ./
+	@echo -e "$(RL)[!] Eliminando archivos objetos de ./$(RE)"
 	rm -f *.o *.h.gch
 	@echo
 # --------------------------------------------------------------------


### PR DESCRIPTION
Ahora se puede bloquear y desbloquear al refmap
mediante las rutinas:
```.c
void refmap_unsafe_lock( RefMap* );
void refmap_unsafe_unlock( RefMap* );
```

**NOTA:** Deben usarse con cuidado.

Además, makefile ahora tiene colores disponibles
para las distribuciones UNIX/Linux.