### PR TITLE
Nuevas funciones inseguras en RefMap y RefQueue

### DIFF
--- a/Tipos/RefMap.c
+++ b/Tipos/RefMap.c
@@ -70,9 +70,6 @@ static int     isRed        ( NodeRB* node );
 static COLOR _flipcolor ( COLOR c );
 
 // Refmap private functions:
-static void refmap_unsafe_delete   ( RefMap* t , void* key );
-static void refmap_unsafe_deleteMin( RefMap* t );
-static void refmap_unsafe_deleteMax( RefMap* t );
 
 static void print_opaque( void *unknow );
 static void debug( NodeRB* x , int indent , int incr ,
@@ -461,7 +458,7 @@ static void* delete( NodeRB** root , void* key , int (*compare)(void*,void*) , N
     return extracted_key;
 }
 
-static void refmap_unsafe_delete( RefMap* t , void* key ){
+void refmap_unsafe_delete( RefMap* t , void* key ){
     static int extra = BOTTOM_STACK_SIZE;
     if( !refmap_unsafe_contains(t,key) ) return;
 
@@ -490,7 +487,7 @@ void refmap_delete( RefMap* t , void* key ){
     pthread_mutex_unlock( &t->lock );
 }
 
-static void refmap_unsafe_deleteMin( RefMap* t ){
+void refmap_unsafe_deleteMin( RefMap* t ){
     static int extra = BOTTOM_STACK_SIZE;
 
     // Initial Interface:
@@ -574,7 +571,7 @@ void refmap_deleteMin( RefMap* t ){
 }
 
 
-static void refmap_unsafe_deleteMax( RefMap* t ){
+void refmap_unsafe_deleteMax( RefMap* t ){
     static int extra = BOTTOM_STACK_SIZE;
 
     // Initial Interface:

--- a/Tipos/RefMap.h
+++ b/Tipos/RefMap.h
@@ -111,12 +111,17 @@ void*  refmap_extract_max_if_key( RefMap* t , int (*predicate)(void*) );
 void*  refmap_unsafe_lock  ( RefMap* t );
 int    refmap_unsafe_unlock( RefMap* t );
 
+void refmap_unsafe_put( RefMap* t , void* key , void* value );
+void   refmap_unsafe_delete   ( RefMap* t , void* key );
+void   refmap_unsafe_deleteMin( RefMap* t );
+void   refmap_unsafe_deleteMax( RefMap* t );
 void*  refmap_unsafe_get   ( RefMap* t , void* key );
 int    refmap_unsafe_empty ( RefMap* t );
 int    refmap_unsafe_size  ( RefMap* t );
 int    refmap_unsafe_contains ( RefMap* t , void* key );
 void*  refmap_unsafe_minkey( RefMap* t );
 void*  refmap_unsafe_maxkey( RefMap* t );
+
 /// @brief Muestra el mapa en stderr.
 /// @param t Mapa objetivo.
 /// @param use_ascii_color Lógico. si es 0, no muestra colores. si es 1 muestra colores. (Formato Unix)
@@ -202,12 +207,41 @@ void   refmap_debug( RefMap* t , int use_ascii_color , void (*print_key)(void*) 
 /// @details Permite liberar a t, luego de que haber sido reservado con refmap_unsafe_lock.
 /// @see refmap_unsafe_lock
 
+/// @fn void refmap_unsafe_put( RefMap* t , void* key , void* value )
+/// @brief Inserta o Reemplaza la referencia de un valor dentro del mapa.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @param value Referencia del valor a insertar/reemplazar.
+/// @warning No es Thread-Safe.
+/// @details Inserta la referencias en el mapa. **NO BLOQUEA EL MAPA.**
+
 /// @fn void* refmap_unsafe_get( RefMap* t , void* key )
 /// @brief Consulta el valor asociado a la clave proporcionada dentro de un mapa.
 /// @param t Mapa objetivo.
 /// @param key Clave de comparación.
 /// @warning No es Thread-safe.
 /// @return Referencia del objeto asociado con key. NULL si no se encuentra dentro del mapa.
+
+/// @fn void refmap_unsafe_delete( RefMap* t , void* key )
+/// @brief Remueve el valor asociado para la clave proporcionada.
+/// @param t Mapa objetivo.
+/// @param key Clave de comparación.
+/// @warning No es Thread-Safe.
+/// @details Remueve la referencia del mapa. **NO BLOQUEA EL MAPA.**
+
+/// @fn void refmap_unsafe_deleteMin( RefMap* t )
+/// @brief Remueve el valor asociado para la clave más pequeña del mapa.
+/// @param t Mapa objetivo.
+/// @warning No es Thread-Safe.
+/// @details Remueve la referencia del mapa. **NO BLOQUEA EL MAPA.**
+/// @see refmap_unsafe_delete
+//
+/// @fn void refmap_unsafe_deleteMax( RefMap* t )
+/// @brief Remueve el valor asociado para la clave más grande del mapa.
+/// @param t Mapa objetivo.
+/// @warning No es Thread-Safe.
+/// @details Remueve la referencia del mapa. **NO BLOQUEA EL MAPA.**
+/// @see refmap_unsafe_delete
 
 /// @fn int refmap_unsafe_empty( RefMap* t );
 /// @brief Verifica si el mapa está vacío.

--- a/Tipos/RefQueue.c
+++ b/Tipos/RefQueue.c
@@ -16,8 +16,6 @@
     } while(0);
 
 // Declaracion de funciones estáticas (visibles sólo para el archivo actual)
-static void  refqueue_unsafe_put  ( RefQueue* qs , void* elem );
-static void* refqueue_unsafe_get  ( RefQueue* qs );
 static char* refqueue_unsafe_str  ( RefQueue* xs );
 static char* opaque_object_str    ( void* ignored );
 
@@ -120,7 +118,7 @@ void* refqueue_tryget( RefQueue* qs ){
     }
 }
 
-static void refqueue_unsafe_put( RefQueue* qs , void* item ){
+void refqueue_unsafe_put( RefQueue* qs , void* item ){
     _LNode* node = new_node( item );
 
     if( refqueue_unsafe_empty(qs) ) {
@@ -133,7 +131,7 @@ static void refqueue_unsafe_put( RefQueue* qs , void* item ){
     qs->n         += 1;
 }
 
-static void* refqueue_unsafe_get( RefQueue* qs ){
+void* refqueue_unsafe_get( RefQueue* qs ){
     _LNode* target = qs->head;
     void*   item   = target->item;
 
@@ -222,9 +220,7 @@ static char* refqueue_unsafe_str( RefQueue* xs ){
 char* refqueue_str( RefQueue* qs ){ // New string must be freed.
     char* str; 
     RefQueue* self = qs;
-    pthread_mutex_lock( &self->lock );
-    str = refqueue_unsafe_str( self );
-    pthread_mutex_unlock( &self->lock );
+    pthread_mutex_lock( &self->lock ); str = refqueue_unsafe_str( self ); pthread_mutex_unlock( &self->lock );
     return str;
 }
 
@@ -269,5 +265,8 @@ void refqueue_deallocateAll( RefQueue* qs ){
     pthread_mutex_destroy( &self->lock );
     pthread_cond_destroy( &self->has_item );
 }
+
+void refqueue_unsafe_lock  ( RefQueue* qs ){ pthread_mutex_lock  ( &qs->lock ); }
+void refqueue_unsafe_unlock( RefQueue* qs ){ pthread_mutex_unlock( &qs->lock ); }
 
 #undef STOP_IF_UNSAFE

--- a/Tipos/RefQueue.h
+++ b/Tipos/RefQueue.h
@@ -61,6 +61,12 @@ void   refqueue_show_in( RefQueue* qs , FILE* stream );
 size_t refqueue_unsafe_len  ( RefQueue* qs );
 int    refqueue_unsafe_empty( RefQueue* qs );
 
+void refqueue_unsafe_lock  ( RefQueue* qs );
+void refqueue_unsafe_unlock( RefQueue* qs );
+
+void  refqueue_unsafe_put  ( RefQueue* qs , void* elem );
+void* refqueue_unsafe_get  ( RefQueue* qs );
+
 /// @fn void refqueue_singleton( RefQueue* qs )
 /// @brief Crea una cola de referencias trivial.
 /// @param qs Cola a inicializar.
@@ -143,4 +149,31 @@ int    refqueue_unsafe_empty( RefQueue* qs );
 /// @warning No es Thread-Safe.
 /// @return Lógico. No se asegura la exclusión mutua.
 
+/// @fn void refqueue_unsafe_lock( RefQueue* qs )
+/// @brief Bloquea la cola qs.
+/// @param qs Cola objetivo.
+/// @warning **PUEDE CAUSAR INTERBLOQUEO.**
+/// @details Reserva a qs para realizar operaciones criticas.
+//
+/// @fn void refqueue_unsafe_unlock( RefQueue* qs )
+/// @brief Bloquea la cola qs.
+/// @param qs Cola objetivo.
+/// @warning **PUEDE GENERAR ERRORES DE EJECUCION SI qs NO ESTABA BLOQUEADO.**
+/// @details Libera a qs luego de realizar operaciones críticas.
+
+/// @fn void refqueue_unsafe_put( RefQueue* qs , void* elem )
+/// @brief Agrega un elemento de forma insegura.
+/// @param qs Cola objetivo.
+/// @param elem Elemento a insertar.
+/// @warning No es Thread-Safe.
+/// @details Inserta la referencia del objeto elem al final de la cola. **NO BLOQUEA LA COLA.**
+
+/// @fn void refqueue_unsafe_get( RefQueue* qs , void* elem )
+/// @brief Remueve un elemento de forma insegura.
+/// @param qs Cola objetivo.
+/// @param elem Elemento a insertar.
+/// @warning No es Thread-Safe.
+/// @return referencia del primer objeto que estaba en la cola.
+/// @details Elimina la referencia del objeto elem que estaba al principio de la cola
+//           y la devuelve. **NO SE BLOQUEARA SI NO HAY NADA EN LA COLA**
 #endif

--- a/Tipos/ejemplos/tryget_queue.c
+++ b/Tipos/ejemplos/tryget_queue.c
@@ -65,7 +65,7 @@ void* konsumidor( void* pair_info ){
     forever {
         ext      = refqueue_tryget( &cola );
         safe_err = errno;
-        if( ext == NULL && safe_err == EBUSY ){
+        if( ext == NULL && safe_err == EAGAIN ){
             printf( "<| %s: Cola vacia.\n" , name );
             printf( "   %s: Manejando Errores.\n" , name );
         } else {

--- a/makefile
+++ b/makefile
@@ -60,7 +60,7 @@ tests: queue-tests refmap-tests
 
 # Genera los casos de prueba para el tipo "Cola de Referencias":
 queue-tests: generic-queue
-	@echo -e "$(BL) [Q] Generando ejemplos de uso para la Cola de Referencias...$(RE)"
+	@echo -e "$(BL) [Q] Generando ejemplos de uso para la $(GL)Cola de Referencias$(BL)...$(RE)"
 	$(CC) $(COMMON) $(TXAMPL)/simple_queue.c       RefQueue.o -o $(TXAMPL)/simple_queue.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/shared_queue.c       RefQueue.o -o $(TXAMPL)/shared_queue.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/quick_shared_queue.c RefQueue.o -o $(TXAMPL)/quick_shared_queue.$(EXT)
@@ -69,7 +69,7 @@ queue-tests: generic-queue
 
 # Genera los casos de prueba para el tipo "Mapa de Referencias":
 refmap-tests: refmap
-	@echo -e "$(BL) [M] Generando ejemplos de uso para el Mapa de Referencias...$(RE)"
+	@echo -e "$(BL) [M] Generando ejemplos de uso para el $(GL)Mapa de Referencias$(BL)...$(RE)"
 	$(CC) $(COMMON) $(TXAMPL)/refmap-allocate.c  RefMap.o -o $(TXAMPL)/refmap-allocate.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/refmap-debug.c     RefMap.o -o $(TXAMPL)/refmap-debug.$(EXT)
 	$(CC) $(COMMON) $(TXAMPL)/refmap-debug-max.c RefMap.o -o $(TXAMPL)/refmap-debug-max.$(EXT)


### PR DESCRIPTION
Se han añadido funciones para usar las primitivas
de exclusión mutua dentro de ambos tipos de datos
y, se actualizó uno de los ejemplos de RefQueue.